### PR TITLE
Convert lat and long to numeric

### DIFF
--- a/global.R
+++ b/global.R
@@ -90,6 +90,8 @@ monsites$meanannflownoangle <- gsub('^.|.$', '', monsites$meanannflow)
 monsites$meanfloodflownoangle <- gsub('^.|.$', '', monsites$meanfloodflow)
 monsites$resultsetnoangle <- gsub('^.|.$', '', monsites$resultset)
 monsites$reachnoangle <- gsub('^.|.$', '', monsites$reach)
+monsites$long <- sapply(monsites$long, as.numeric)
+monsites$lat <- sapply(monsites$lat, as.numeric)
 #monsites <- monsites[which (monsites$mtype == "<https://registry.scinfo.org.nz/lab/nems/def/property/flow-water-level>"), ]
 
 dtmonsites <- data.frame("Name" = paste0('<a href="http://envdatapoc.co.nz/doc/measurement-site/',monsites$siteID,'?tab=api" target="_blank">',monsites$name,'</a>'),


### PR DESCRIPTION
Hi,

Thank you for this R shiny app. I am currently installing it on a new server with Ansible. As the installation failed, I tried to reproduce it locally, but also got the same error I had in the server.

I installed the dependencies from what I found in `global.R`, and below is the command used to run locally, and its output after the browser was launched (I deployed to the server with Ansible from a git commit hash, to an existing R Shiny + nginx server).

```
$ shiny::runGitHub('nz_shiny_river_app', 'Swirrl')
Downloading https://github.com/Swirrl/nz_shiny_river_app/archive/master.tar.gz

Listening on http://127.0.0.1:7054
Warning in classIntervals(monsites$percdiffmean, n = 6, style = "fixed",  :
  var has missing values, omitted in finding classes
Warning in classIntervals(monsites$percdiffmax, n = 6, style = "fixed",  :
  var has missing values, omitted in finding classes
Assuming 'long' and 'lat' are longitude and latitude, respectively
Warning: Error in validateCoords: addCircleMarkers requires numeric longitude/latitude values
Stack trace (innermost first):
    68: validateCoords
    67: derivePoints
    66: addCircleMarkers
    65: function_list[[i]]
    64: freduce
    63: _fseq
    62: eval
    61: eval
    60: withVisible
    59: %>%
    58: observerFunc [/tmp/RtmpiXou2D/shinyapp1b8a5b8febd8/nz_shiny_river_app-master/server.R#175]
     3: runApp
     2: runUrl
     1: shiny::runGitHub
```

First I looked at leaflet, and it seems like [the code that throws this error](https://github.com/rstudio/leaflet/blob/d489e2cd8dd2c6b96a287d70ef46cd67682d9be9/R/utils.R#L276) is simply **confirming latitude and longitude are numeric**.

So I fired `R` in my terminal, and did just the SPARQL query from `global.R`, and checked if I got numeric or character.

```
$ R
R version 3.4.2 (2017-09-28) -- "Short Summer"
Copyright (C) 2017 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> library('SPARQL')
Loading required package: XML
Loading required package: RCurl
Loading required package: bitops
> endpoint <- "http://guest:eidipoc@envdatapoc.co.nz/sparql" #with simple authentication
> 
> startquery <-  "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+ SELECT DISTINCT *
+ WHERE {
+ {SELECT (max(?datetime) AS ?latest) ?sitesub
+ WHERE {
+ ?obs <http://www.w3.org/ns/sosa/observedProperty> <https://registry.scinfo.org.nz/lab/nems/def/property/flow-water-level> .
+ ?obs rdf:type <http://www.w3.org/ns/sosa/Observation> .
+ ?obs <http://www.w3.org/ns/sosa/hasFeatureOfInterest> ?sitesub .
+ ?obs <http://www.w3.org/ns/sosa/resultTime> ?datetime .
+ }
+ GROUP BY ?sitesub
+ }
+ ?obs <http://www.w3.org/ns/sosa/resultTime> ?latest .
+ ?obs <http://www.w3.org/ns/sosa/hasFeatureOfInterest> ?sitesub .  
+ ?obs <http://www.w3.org/ns/sosa/hasResult> ?resultset .
+ ?obs <http://www.w3.org/ns/sosa/observedProperty> <https://registry.scinfo.org.nz/lab/nems/def/property/flow-water-level> .
+ ?sitesub <http://envdatapoc.co.nz/def/lawaSiteID> ?siteID .
+ ?resultset <http://qudt.org/1.1/schema/qudt#numericValue> ?value .
+ ?sitesub<http://www.w3.org/2003/01/geo/wgs84_pos#lat> ?lat .
+ ?sitesub<http://www.w3.org/2003/01/geo/wgs84_pos#long> ?long .
+ ?sitesub rdfs:label ?name .
+ OPTIONAL {?sitesub <http://envdatapoc.co.nz/def/MALF> ?malf .
+ ?malf <http://qudt.org/1.1/schema/qudt#numericValue> ?malfval .}
+ OPTIONAL {?sitesub <http://envdatapoc.co.nz/def/maxRecordedFlow> ?maxflow .
+ ?maxflow <http://qudt.org/1.1/schema/qudt#numericValue> ?maxflowval .}
+ OPTIONAL {?sitesub <http://envdatapoc.co.nz/def/meanAnnualFlow> ?meanannflow .
+ ?meanannflow <http://qudt.org/1.1/schema/qudt#numericValue> ?meanannflowval . }
+ OPTIONAL {?sitesub <http://envdatapoc.co.nz/def/meanAnnualFloodFlow> ?meanfloodflow .
+ ?meanfloodflow <http://qudt.org/1.1/schema/qudt#numericValue> ?meanfloodflowval .}
+ OPTIONAL {?sitesub <http://envdatapoc.co.nz/def/minRecordedFlow> ?minflow .
+ ?minflow <http://qudt.org/1.1/schema/qudt#numericValue> ?minflowval .}
+ OPTIONAL {?sitesub <http://envdatapoc.co.nz/def/catchment> ?catchment .
+ ?catchment rdfs:label ?catchmentname .}
+ OPTIONAL {?sitesub <http://envdatapoc.co.nz/def/managementZone> ?mgmnt .}
+ OPTIONAL {?sitesub <http://envdatapoc.co.nz/def/reach> ?reach .
+ ?reach rdfs:label ?reachlabel . 
+ ?reach <http://envdatapoc.co.nz/def/climate> ?climate .
+ ?reach <http://envdatapoc.co.nz/def/geology> ?geology .
+ ?reach <http://envdatapoc.co.nz/def/landcover> ?landcover .
+ ?climate rdfs:label ?climatelabel.
+ ?geology rdfs:label ?geologylabel.
+ ?landcover rdfs:label ?landcoverlabel .
+ }
+ OPTIONAL {?sitesub <http://envdatapoc.co.nz/def/elevation> ?elevation .}
+ OPTIONAL {?sitesub <http://schema.org/image> ?image .}
+ }"
> qd <- SPARQL(endpoint,startquery)
> monsites <- qd$results
> monsites$long[is.numeric(monsites$long)]
character(0)
> monsites$long[is.character(monsites$long)]
  [1] "175.78086000000008" "176.01202000000012" "175.74511000000007"
  [4] "175.93115000000023" "175.21164999999996" "175.62773000000004"
  [7] "175.96286000000009" "175.81803000000014" "176.11638000000005"
 [10] "175.79173000000003" "175.61099000000002" "175.83121000000028"
 [13] "176.1895300000001"  "175.32311000000004" "175.03237999999999"
 [16] "175.65990000000011" "176.03234000000009" "176.30245000000002"
 [19] "175.78300000000002" "175.46384000000012" "175.80810999999994"
 [22] "176.04425000000015" "175.99543000000006" "175.92279000000008"
 [25] "175.23333000000002" "175.23359000000005" "175.27567999999997"
 [28] "175.04452000000015" "175.65775000000008" "175.53265999999996"
 [31] "175.33113000000003" "175.33267999999998" "176.06362999999999"
 [34] "175.46276000000012" "175.49659999999994" "175.63931400000001"
 [37] "176.06793500000003" "175.4985210000001"  "176.79843650299495"
 [40] "176.79676255852382" "176.8211593248115"  "177.58433985307798"
 [43] "176.80743508835894" "176.50638408211697" "177.85825035486607"
 [46] "176.71909994279662" "176.55584956831433" "176.88946828278486"
 [49] "176.57850437029109" "176.76031961195429" "176.39836659520225"
 [52] "176.735318811648"   "176.59112133176419" "176.33420299898668"
 [55] "176.92789556720999" "176.60999499187474" "176.78857899579418"
 [58] "177.29031599920268" "177.19163641521246" "176.97914358117973"
 [61] "176.57363779098148" "177.45307569766098" "176.28075877311508"
 [64] "176.95300133670918" "176.82298631956957" "173.6798464705099" 
 [67] "172.7739448904655"  "172.6494718896204"  "173.3586616695579" 
 [70] "173.0943681021134"  "172.3272220623372"  "172.6148463680445" 
 [73] "172.2169131456905"  "172.3886159818084"  "172.6520065229004" 
 [76] "171.9466972231844"  "172.611967440511"   "172.6504523849554" 
 [79] "172.634290492932"   "172.6478726298938"  "173.0357624264524" 
 [82] "172.9695197615237"  "172.6819743388365"  "172.5421811800271" 
 [85] "171.8360005645311"  "172.0365069696218"  "172.2829146736315" 
 [88] "171.7499715083275"  "171.4888081413739"  "171.4794294892828" 
 [91] "171.4457074367582"  "171.2714893320175"  "171.2203672503986" 
 [94] "171.1982220115364"  "171.2691667075501"  "170.9431316971815" 
 [97] "170.757259032581"   "170.9754745228941"  "171.1074239912201" 
[100] "171.0479115863547"  "170.9735547836567"  "170.4511727735924" 
[103] "169.953053361092"   "170.668820813284"   "169.8846266492253" 
[106] "169.9511509226712"  "170.7745272225315"  "173.0612366043842" 
[109] "175.70730590201728" "175.12928181532294" "175.19327633571893"
[112] "174.76968463881602" "175.59052239267885" "175.28981139758034"
[115] "175.74573011202051"
``` 

So it looked like the query was returning text instead of numbers. Then I accessed the SPARQL endpoint at [http://user:pass@envdatapoc.co.nz/sparql](http://user:pass@envdatapoc.co.nz/sparql), and executed the same query with result set to JSON. Then looked for one of the longitudes from the output above.

The query takes a bit, and then on searching for 175.74573011202051, I found the following in the JSON output:

```
...
        "long" : {
          "type" : "literal",
          "value" : "175.74573011202051"
        },
...
```

For a comparison, the `value` entry seems to be correctly typed to a double:

```
        "value" : {
          "datatype" : "http://www.w3.org/2001/XMLSchema#double",
          "type" : "literal",
          "value" : "3.676"
        },
```

As the R output indicates too.

```
> monsites$long[is.character(monsites$value)]
character(0)
> monsites$long[is.numeric(monsites$value)]
  [1] "175.78086000000008" "176.01202000000012" "175.74511000000007"
  [4] "175.93115000000023" "175.21164999999996" "175.62773000000004"
  [7] "175.96286000000009" "175.81803000000014" "176.11638000000005"
 [10] "175.79173000000003" "175.61099000000002" "175.83121000000028"
 [13] "176.1895300000001"  "175.32311000000004" "175.03237999999999"
 [16] "175.65990000000011" "176.03234000000009" "176.30245000000002"
 [19] "175.78300000000002" "175.46384000000012" "175.80810999999994"
 [22] "176.04425000000015" "175.99543000000006" "175.92279000000008"
 [25] "175.23333000000002" "175.23359000000005" "175.27567999999997"
 [28] "175.04452000000015" "175.65775000000008" "175.53265999999996"
 [31] "175.33113000000003" "175.33267999999998" "176.06362999999999"
 [34] "175.46276000000012" "175.49659999999994" "175.63931400000001"
 [37] "176.06793500000003" "175.4985210000001"  "176.79843650299495"
 [40] "176.79676255852382" "176.8211593248115"  "177.58433985307798"
 [43] "176.80743508835894" "176.50638408211697" "177.85825035486607"
 [46] "176.71909994279662" "176.55584956831433" "176.88946828278486"
 [49] "176.57850437029109" "176.76031961195429" "176.39836659520225"
 [52] "176.735318811648"   "176.59112133176419" "176.33420299898668"
 [55] "176.92789556720999" "176.60999499187474" "176.78857899579418"
 [58] "177.29031599920268" "177.19163641521246" "176.97914358117973"
 [61] "176.57363779098148" "177.45307569766098" "176.28075877311508"
 [64] "176.95300133670918" "176.82298631956957" "173.6798464705099" 
 [67] "172.7739448904655"  "172.6494718896204"  "173.3586616695579" 
 [70] "173.0943681021134"  "172.3272220623372"  "172.6148463680445" 
 [73] "172.2169131456905"  "172.3886159818084"  "172.6520065229004" 
 [76] "171.9466972231844"  "172.611967440511"   "172.6504523849554" 
 [79] "172.634290492932"   "172.6478726298938"  "173.0357624264524" 
 [82] "172.9695197615237"  "172.6819743388365"  "172.5421811800271" 
 [85] "171.8360005645311"  "172.0365069696218"  "172.2829146736315" 
 [88] "171.7499715083275"  "171.4888081413739"  "171.4794294892828" 
 [91] "171.4457074367582"  "171.2714893320175"  "171.2203672503986" 
 [94] "171.1982220115364"  "171.2691667075501"  "170.9431316971815" 
 [97] "170.757259032581"   "170.9754745228941"  "171.1074239912201" 
[100] "171.0479115863547"  "170.9735547836567"  "170.4511727735924" 
[103] "169.953053361092"   "170.668820813284"   "169.8846266492253" 
[106] "169.9511509226712"  "170.7745272225315"  "173.0612366043842" 
[109] "175.70730590201728" "175.12928181532294" "175.19327633571893"
[112] "174.76968463881602" "175.59052239267885" "175.28981139758034"
[115] "175.74573011202051"
```

Finally, I changed the code a bit to convert the whole `lat` and `long` columns to a numeric value, and then the application loaded correctly once launched via `shiny::runGitHub`.

It could be that the SPARQL endpoint changed the datatypes, or that some library was recently updated, or even that my environment contains something that triggers this issue. But I think this change may be safe, and prevent the issue from happening.

Don't really write much R code, so feel free to thoroughly review the pull request, and provide any feedback in case what I said here does not make sense.

Thank you
Bruno